### PR TITLE
式の解析にpratt parsingを導入する

### DIFF
--- a/src/lib/running/binary-expr.ts
+++ b/src/lib/running/binary-expr.ts
@@ -1,5 +1,6 @@
 import { UguisuError } from '../misc/errors.js';
 import { ArithmeticOperator, EquivalentOperator, LogicalBinaryOperator, OrderingOperator } from '../syntax/node.js';
+import { Token } from '../syntax/token.js';
 import { createOk, EvalResult } from './result.js';
 import {
     assertValue,
@@ -20,10 +21,10 @@ export function evalLogicalBinaryOp(op: LogicalBinaryOperator, left: Value, righ
     assertValue(left, 'BoolValue');
     assertValue(right, 'BoolValue');
     switch (op) {
-        case '&&': {
+        case Token.And2: {
             return createOk(createBoolValue(left && right));
         }
-        case '||': {
+        case Token.Or2: {
             return createOk(createBoolValue(left || right));
         }
     }
@@ -41,10 +42,10 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as NumberValue;
             assertValue(right, 'NumberValue');
             switch (op) {
-                case '==': {
+                case Token.Eq: {
                     return createOk(createBoolValue(left == right));
                 }
-                case '!=': {
+                case Token.NotEq: {
                     return createOk(createBoolValue(left != right));
                 }
             }
@@ -54,10 +55,10 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as BoolValue;
             assertValue(right, 'BoolValue');
             switch (op) {
-                case '==': {
+                case Token.Eq: {
                     return createOk(createBoolValue(left == right));
                 }
-                case '!=': {
+                case Token.NotEq: {
                     return createOk(createBoolValue(left != right));
                 }
             }
@@ -67,10 +68,10 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as CharValue;
             assertValue(right, 'CharValue');
             switch (op) {
-                case '==': {
+                case Token.Eq: {
                     return createOk(createBoolValue(left == right));
                 }
-                case '!=': {
+                case Token.NotEq: {
                     return createOk(createBoolValue(left != right));
                 }
             }
@@ -80,10 +81,10 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as StringValue;
             assertValue(right, 'StringValue');
             switch (op) {
-                case '==': {
+                case Token.Eq: {
                     return createOk(createBoolValue(left == right));
                 }
-                case '!=': {
+                case Token.NotEq: {
                     return createOk(createBoolValue(left != right));
                 }
             }
@@ -102,10 +103,10 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as FunctionValue;
             assertValue(right, 'FunctionValue');
             switch (op) {
-                case '==': {
+                case Token.Eq: {
                     return createOk(createBoolValue(equalFunc(left, right)));
                 }
-                case '!=': {
+                case Token.NotEq: {
                     return createOk(createBoolValue(!equalFunc(left, right)));
                 }
             }
@@ -128,18 +129,19 @@ export function evalOrderingBinaryOp(op: OrderingOperator, left: Value, right: V
     }
     switch (getValueKind(left)) {
         case 'NumberValue': {
+            left = left as NumberValue;
             assertValue(right, 'NumberValue');
             switch (op) {
-                case '<': {
+                case Token.LessThan: {
                     return createOk(createBoolValue(left < right));
                 }
-                case '<=': {
+                case Token.LessThanEq: {
                     return createOk(createBoolValue(left <= right));
                 }
-                case '>': {
+                case Token.GreaterThan: {
                     return createOk(createBoolValue(left > right));
                 }
-                case '>=': {
+                case Token.GreaterThanEq: {
                     return createOk(createBoolValue(left >= right));
                 }
             }
@@ -161,19 +163,19 @@ export function evalArithmeticBinaryOp(op: ArithmeticOperator, left: Value, righ
     assertValue(left, 'NumberValue');
     assertValue(right, 'NumberValue');
     switch (op) {
-        case '+': {
+        case Token.Plus: {
             return createOk(createNumberValue(left + right));
         }
-        case '-': {
+        case Token.Minus: {
             return createOk(createNumberValue(left - right));
         }
-        case '*': {
+        case Token.Asterisk: {
             return createOk(createNumberValue(left * right));
         }
-        case '/': {
+        case Token.Slash: {
             return createOk(createNumberValue(left / right));
         }
-        case '%': {
+        case Token.Percent: {
             return createOk(createNumberValue(left % right));
         }
     }

--- a/src/lib/running/binary-expr.ts
+++ b/src/lib/running/binary-expr.ts
@@ -42,7 +42,7 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as NumberValue;
             assertValue(right, 'NumberValue');
             switch (op) {
-                case Token.Eq: {
+                case Token.Eq2: {
                     return createOk(createBoolValue(left == right));
                 }
                 case Token.NotEq: {
@@ -55,7 +55,7 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as BoolValue;
             assertValue(right, 'BoolValue');
             switch (op) {
-                case Token.Eq: {
+                case Token.Eq2: {
                     return createOk(createBoolValue(left == right));
                 }
                 case Token.NotEq: {
@@ -68,7 +68,7 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as CharValue;
             assertValue(right, 'CharValue');
             switch (op) {
-                case Token.Eq: {
+                case Token.Eq2: {
                     return createOk(createBoolValue(left == right));
                 }
                 case Token.NotEq: {
@@ -81,7 +81,7 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as StringValue;
             assertValue(right, 'StringValue');
             switch (op) {
-                case Token.Eq: {
+                case Token.Eq2: {
                     return createOk(createBoolValue(left == right));
                 }
                 case Token.NotEq: {
@@ -103,7 +103,7 @@ export function evalEquivalentBinaryOp(op: EquivalentOperator, left: Value, righ
             left = left as FunctionValue;
             assertValue(right, 'FunctionValue');
             switch (op) {
-                case Token.Eq: {
+                case Token.Eq2: {
                     return createOk(createBoolValue(equalFunc(left, right)));
                 }
                 case Token.NotEq: {

--- a/src/lib/running/run.ts
+++ b/src/lib/running/run.ts
@@ -12,6 +12,7 @@ import {
     StatementNode,
     StepNode
 } from '../syntax/node.js';
+import { Token } from '../syntax/token.js';
 import {
     evalArithmeticBinaryOp,
     evalEquivalentBinaryOp,
@@ -388,7 +389,7 @@ function evalExpr(r: RunContext, expr: ExprNode): EvalResult<Value> {
             // Logical Operation
             assertValue(result.value, 'BoolValue');
             switch (expr.operator) {
-                case '!': {
+                case Token.Not: {
                     return createOk(createBoolValue(!result.value));
                 }
             }

--- a/src/lib/syntax/node.ts
+++ b/src/lib/syntax/node.ts
@@ -1,3 +1,5 @@
+import { Token } from './token.js';
+
 export type Pos = [number, number];
 
 export type SyntaxNode =
@@ -202,8 +204,7 @@ export type UnaryOp = {
 export function createUnaryOp(pos: Pos, operator: UnaryOperator, expr: ExprNode): UnaryOp {
     return { kind: 'UnaryOp', pos, operator, expr };
 }
-export type UnaryOperator = LogicalUnaryOperator;
-export type LogicalUnaryOperator = '!';
+export type UnaryOperator = Token.Not | Token.Plus | Token.Minus;
 
 export type BinaryOp = {
     kind: 'BinaryOp',
@@ -224,29 +225,29 @@ export function createBinaryOp(
 export type BinaryOperator =
     LogicalBinaryOperator | EquivalentOperator | OrderingOperator | ArithmeticOperator;
 
-export type LogicalBinaryOperator = '||' | '&&';
-const logicalBinaryOperators: BinaryOperator[] = ['||', '&&'];
+export type LogicalBinaryOperator = Token.Or2 | Token.And2;
+const logicalBinaryOperators: BinaryOperator[] = [Token.Or2, Token.And2];
 
 export function isLogicalBinaryOperator(x: BinaryOperator): x is LogicalBinaryOperator {
     return logicalBinaryOperators.includes(x);
 }
 
-export type EquivalentOperator = '==' | '!=';
-const equivalentOperators: BinaryOperator[] = ['==', '!='];
+export type EquivalentOperator = Token.Eq | Token.NotEq;
+const equivalentOperators: BinaryOperator[] = [Token.Eq, Token.NotEq];
 
 export function isEquivalentOperator(x: BinaryOperator): x is EquivalentOperator {
     return equivalentOperators.includes(x);
 }
 
-export type OrderingOperator = '<' |'<=' | '>' | '>=';
-const orderingOperators: BinaryOperator[] = ['<', '<=', '>', '>='];
+export type OrderingOperator = Token.LessThan | Token.LessThanEq | Token.GreaterThan | Token.GreaterThanEq;
+const orderingOperators: BinaryOperator[] = [Token.LessThan, Token.LessThanEq, Token.GreaterThan, Token.GreaterThanEq];
 
 export function isOrderingOperator(x: BinaryOperator): x is OrderingOperator {
     return orderingOperators.includes(x);
 }
 
-export type ArithmeticOperator = '+' | '-' | '*' | '/' | '%';
-const arithmeticOperators: BinaryOperator[] = ['+', '-', '*', '/', '%'];
+export type ArithmeticOperator = Token.Plus | Token.Minus | Token.Asterisk | Token.Slash | Token.Percent;
+const arithmeticOperators: BinaryOperator[] = [Token.Plus, Token.Minus, Token.Asterisk, Token.Slash, Token.Percent];
 
 export function isArithmeticOperator(x: BinaryOperator): x is ArithmeticOperator {
     return arithmeticOperators.includes(x);

--- a/src/lib/syntax/node.ts
+++ b/src/lib/syntax/node.ts
@@ -232,8 +232,8 @@ export function isLogicalBinaryOperator(x: BinaryOperator): x is LogicalBinaryOp
     return logicalBinaryOperators.includes(x);
 }
 
-export type EquivalentOperator = Token.Eq | Token.NotEq;
-const equivalentOperators: BinaryOperator[] = [Token.Eq, Token.NotEq];
+export type EquivalentOperator = Token.Eq2 | Token.NotEq;
+const equivalentOperators: BinaryOperator[] = [Token.Eq2, Token.NotEq];
 
 export function isEquivalentOperator(x: BinaryOperator): x is EquivalentOperator {
     return equivalentOperators.includes(x);

--- a/src/lib/syntax/parse.ts
+++ b/src/lib/syntax/parse.ts
@@ -520,7 +520,7 @@ type InfixToken =
     | Token.LessThanEq
     | Token.GreaterThan
     | Token.GreaterThanEq
-    | Token.Eq
+    | Token.Eq2
     | Token.NotEq
     | Token.And2
     | Token.Or2;
@@ -548,7 +548,7 @@ const operators: OpInfo[] = [
     infixOp(Token.LessThanEq, 50, 51),
     infixOp(Token.GreaterThan, 50, 51),
     infixOp(Token.GreaterThanEq, 50, 51),
-    infixOp(Token.Eq, 40, 41),
+    infixOp(Token.Eq2, 40, 41),
     infixOp(Token.NotEq, 40, 41),
     infixOp(Token.And2, 30, 31),
     infixOp(Token.Or2, 20, 21),

--- a/src/lib/syntax/scan.ts
+++ b/src/lib/syntax/scan.ts
@@ -254,7 +254,7 @@ export class Scanner {
                 case '=': {
                     this.nextChar();
                     if (this.ch == '=') {
-                        this.token = Token.Eq;
+                        this.token = Token.Eq2;
                         this.nextChar();
                     } else {
                         this.token = Token.Assign;

--- a/src/lib/syntax/token.ts
+++ b/src/lib/syntax/token.ts
@@ -46,7 +46,7 @@ export enum Token {
     /** "%=" */
     ModAssign,
     /** "==" */
-    Eq,
+    Eq2,
     /** ">" */
     GreaterThan,
     /** ">=" */

--- a/src/lib/wasm/codegen.ts
+++ b/src/lib/wasm/codegen.ts
@@ -232,7 +232,7 @@ function translateExpr(ctx: Context, node: ExprNode, func: FuncInfo): number {
                 }
             } else if (compareType(symbol.ty, boolType) == 'compatible') {
                 switch (node.operator) {
-                    case Token.Eq: {
+                    case Token.Eq2: {
                         return ctx.mod.i32.eq(left, right);
                     }
                     case Token.NotEq: {

--- a/src/lib/wasm/codegen.ts
+++ b/src/lib/wasm/codegen.ts
@@ -3,6 +3,7 @@ import { UguisuError } from '../misc/errors.js';
 import { boolType, compareType, FunctionType, numberType, Type, voidType } from '../semantics/type.js';
 import { Symbol } from '../semantics/symbol.js';
 import { SyntaxNode, ExprNode, FileNode, Identifier, SourceFile, StepNode } from '../syntax/node.js';
+import { Token } from '../syntax/token.js';
 
 export function codegen(symbolTable: Map<SyntaxNode, Symbol>, node: SourceFile) {
     const mod = translate(symbolTable, node);
@@ -213,16 +214,16 @@ function translateExpr(ctx: Context, node: ExprNode, func: FuncInfo): number {
             const right = translateExpr(ctx, node.right, func);
             if (compareType(symbol.ty, numberType) == 'compatible') {
                 switch (node.operator) {
-                    case '+': {
+                    case Token.Plus: {
                         return ctx.mod.i32.add(left, right);
                     }
-                    case '-': {
+                    case Token.Minus: {
                         return ctx.mod.i32.sub(left, right);
                     }
-                    case '*': {
+                    case Token.Asterisk: {
                         return ctx.mod.i32.mul(left, right);
                     }
-                    case '/': {
+                    case Token.Slash: {
                         return ctx.mod.i32.div_s(left, right);
                     }
                     default: {
@@ -231,28 +232,28 @@ function translateExpr(ctx: Context, node: ExprNode, func: FuncInfo): number {
                 }
             } else if (compareType(symbol.ty, boolType) == 'compatible') {
                 switch (node.operator) {
-                    case '==': {
+                    case Token.Eq: {
                         return ctx.mod.i32.eq(left, right);
                     }
-                    case '!=': {
+                    case Token.NotEq: {
                         return ctx.mod.i32.ne(left, right);
                     }
-                    case '<': {
+                    case Token.LessThan: {
                         return ctx.mod.i32.lt_s(left, right);
                     }
-                    case '<=': {
+                    case Token.LessThanEq: {
                         return ctx.mod.i32.le_s(left, right);
                     }
-                    case '>': {
+                    case Token.GreaterThan: {
                         return ctx.mod.i32.gt_s(left, right);
                     }
-                    case '>=': {
+                    case Token.GreaterThanEq: {
                         return ctx.mod.i32.ge_s(left, right);
                     }
-                    case '&&': {
+                    case Token.And2: {
                         return ctx.mod.i32.and(left, right);
                     }
-                    case '||': {
+                    case Token.Or2: {
                         return ctx.mod.i32.or(left, right);
                     }
                     default: {
@@ -271,8 +272,14 @@ function translateExpr(ctx: Context, node: ExprNode, func: FuncInfo): number {
             }
             const expr = translateExpr(ctx, node.expr, func);
             switch (node.operator) {
-                case '!': {
+                case Token.Not: {
                     return ctx.mod.i32.eq(expr, ctx.mod.i32.const(0));
+                }
+                case Token.Plus: {
+                    return expr;
+                }
+                case Token.Minus: {
+                    return ctx.mod.i32.sub(ctx.mod.i32.const(0), expr);
                 }
                 default: {
                     throw new UguisuError('unsupported operation');


### PR DESCRIPTION
現状はprecedence climbingを使っている。
pratt parsingを導入して、式の解析を単純化する。

参考:
https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html 